### PR TITLE
Add cart event handling to RjPixel

### DIFF
--- a/src/App.server.jsx
+++ b/src/App.server.jsx
@@ -1,5 +1,6 @@
 import renderHydrogen from '@shopify/hydrogen/entry-server'
 import {
+  gql,
   Router,
   FileRoutes,
   ShopifyProvider,
@@ -30,7 +31,7 @@ function App({request, response, search}) {
   }
   return (
     <ShopifyProvider>
-      <CartProvider>
+      <CartProvider cartFragment={CART_FRAGMENT}>
         <Suspense>
           <DefaultSeo />
         </Suspense>
@@ -42,5 +43,118 @@ function App({request, response, search}) {
     </ShopifyProvider>
   )
 }
+
+const CART_FRAGMENT = gql`
+fragment CartFragment on Cart {
+  id
+  checkoutUrl
+  totalQuantity
+  buyerIdentity {
+    countryCode
+    customer {
+      id
+      email
+      firstName
+      lastName
+      displayName
+    }
+    email
+    phone
+  }
+  lines(first: $numCartLines) {
+    edges {
+      node {
+        id
+        quantity
+        attributes {
+          key
+          value
+        }
+        cost {
+          totalAmount {
+            amount
+            currencyCode
+          }
+          compareAtAmountPerQuantity {
+            amount
+            currencyCode
+          }
+        }
+        merchandise {
+          ... on ProductVariant {
+            id
+            availableForSale
+            compareAtPriceV2 {
+              ...MoneyFragment
+            }
+            priceV2 {
+              ...MoneyFragment
+            }
+            requiresShipping
+            title
+            image {
+              ...ImageFragment
+            }
+            product {
+              id
+              handle
+              title
+              vendor
+              productType
+              description
+              onlineStoreUrl
+              collections(first: 99) {
+                edges {
+                  node {
+                    title
+                  }
+                }
+              }
+            }
+            selectedOptions {
+              name
+              value
+            }
+            sku
+          }
+        }
+      }
+    }
+  }
+  cost {
+    subtotalAmount {
+      ...MoneyFragment
+    }
+    totalAmount {
+      ...MoneyFragment
+    }
+    totalDutyAmount {
+      ...MoneyFragment
+    }
+    totalTaxAmount {
+      ...MoneyFragment
+    }
+  }
+  note
+  attributes {
+    key
+    value
+  }
+  discountCodes {
+    code
+  }
+}
+fragment MoneyFragment on MoneyV2 {
+  currencyCode
+  amount
+}
+fragment ImageFragment on Image {
+  id
+  url
+  altText
+  width
+  height
+}
+`
 
 export default renderHydrogen(App);

--- a/src/components/RjPixel.client.jsx
+++ b/src/components/RjPixel.client.jsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect } from 'react'
+import { useEffect } from 'react'
 import { ClientAnalytics, loadScript } from '@shopify/hydrogen'
 
 const {


### PR DESCRIPTION
This implementation of the Rejoiner cart events matches data in the event payload itself to target the item(s) being modified and a `cartFragment` prop has been passed to `CartProvider` to supply missing data: url, description, and collections.

The fragment used is taken directly from the `defaultCartFragment` and modified to include those additional values.

See: https://github.com/Shopify/hydrogen/blob/v1.x-2022-07/packages/hydrogen/src/components/CartProvider/cart-queries.ts

The issue with how you used data passed via `useServerAnalytics` is that those data are fixed at page render and coupled to the query configured on that route. This is problematic because the data is not coupled to the specifics of the event itself.

It works fine for product views because the query is rendered for the product template specifically, but it quickly becomes problematic in any other context.

For example, when these events fire from any other page than a `/shop/products/*` route, the tags will fail because the data is not available in that context. Additionally, if a product were to have variant options, the carting events would not target correctly depending on which variant is being selected and added/removed/updated in the cart.